### PR TITLE
Fix conflicts with other mods patching GetGizmos

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# top-most EditorConfig file
+root = true
+
+# 4 space indentation
+[*.{cs,xml}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
( Honestly this should be a Harmony update but this can probably get an update faster. )

Making sure GetGizmo patches are on the declaring type, fixing conflicts with other mods (e.g. What Is My Purpose):


Corpse is an IBillGiver, so it gets GetGizmo patches.
But there is no Corpse.GetGizmos override, so Harmony actually patches ThingWithComps.GetGizmos
But! Harmony would treat Corpse.GetGizmos and ThingWithComps.GetGizmos as different methods, and wouldn't patch them at the same time - one patch would override the other = conflict.
